### PR TITLE
Change request proposal to resolve message codes for validation fields error form post result 

### DIFF
--- a/src/main/java/ch/ralscha/extdirectspring/bean/ExtDirectFormPostResult.java
+++ b/src/main/java/ch/ralscha/extdirectspring/bean/ExtDirectFormPostResult.java
@@ -18,7 +18,6 @@ package ch.ralscha.extdirectspring.bean;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -82,11 +81,7 @@ public class ExtDirectFormPostResult {
 				String message = fieldError.getDefaultMessage();
 				if (messageSource != null) {
 					Locale loc = (locale != null ? locale : Locale.getDefault());
-					for (String code : fieldError.getCodes()) {
-					    message = messageSource.getMessage(code, fieldError.getArguments(), loc);
-					    if (message != null)
-					        break;
-                    }
+					message = messageSource.getMessage(fieldError.getCode(), fieldError.getArguments(), loc);
 				}
 				List<String> fieldErrors = errorMap.get(fieldError.getField());
 
@@ -108,6 +103,61 @@ public class ExtDirectFormPostResult {
 		}
 	}
 
+    /**
+     * resolve the messages codes along the implementation described in {@link org.springframework.validation.DefaultMessageCodesResolver}<br>
+     * stop at first message found<br>
+     * method is useless if no specific validation message have been set (example: javax.validation.constraints.NotNull.message.fax=Fax number is mandatory)<br> 
+     * it will behave {@link #addErrors(Locale, MessageSource, BindingResult)} with a big overhead
+     * 
+     * @param locale locale for internationalization
+     * @param messageSource source of validation code and message
+     * @param bindingResult Errors list to resolve
+     * @return this {@link #ExtDirectFormPostResult} for easy chaining
+     */
+    public ExtDirectFormPostResult addErrorsResolveCode(Locale locale, MessageSource messageSource, BindingResult bindingResult) {
+        if (bindingResult != null && bindingResult.hasFieldErrors()) {
+            Map<String, List<String>> errorMap = new HashMap<String, List<String>>();
+            for (FieldError fieldError : bindingResult.getFieldErrors()) {
+                String message = fieldError.getDefaultMessage();
+                if (messageSource != null) {
+                    Locale loc = (locale != null ? locale : Locale.getDefault());
+                    for (String code : fieldError.getCodes()) {
+                        try {
+                            message = messageSource.getMessage(code, fieldError.getArguments(), loc);
+                        } catch (Exception e) {
+                            /**
+                             * expected if code/message doesn't exist, default behavior
+                             * to counter that, set to your message bundle, 
+                             * {@link org.springframework.context.support.AbstractMessageSource#setUseCodeAsDefaultMessage(true)}
+                             * beware of side effects
+                             */
+                        }
+                        if (message != null && !message.equals(code))
+                            break;
+                    }
+                }
+                List<String> fieldErrors = errorMap.get(fieldError.getField());
+
+                if (fieldErrors == null) {
+                    fieldErrors = new ArrayList<String>();
+                    errorMap.put(fieldError.getField(), fieldErrors);
+                }
+
+                fieldErrors.add(message);
+            }
+            if (errorMap.isEmpty()) {
+                addResultProperty(SUCCESS_PROPERTY, true);
+            } else {
+                addResultProperty(ERRORS_PROPERTY, errorMap);
+                addResultProperty(SUCCESS_PROPERTY, false);
+            }
+        } else {
+            setSuccess(true);
+        }
+        return this;
+    }
+	
+	
 	/**
 	 * Adds one error message to a specific field. Does not overwrite already
 	 * existing errors.


### PR DESCRIPTION
Hi,

I'm using additional information on rather stern validation error messages along what Spring proposed under 
http://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/htmlsingle/#validation-conversion

The change I propose let me define such error messages
javax.validation.constraints.NotNull.message.ph=Valid Phone number must be set
javax.validation.constraints.NotNull.message.fax=Valid Fax number must be set

in a message resource bundle (in my case specific to validation).

Your implementation prevent to get javax.validation.constraints.NotNull.message.fax as the last one is always javax.validation.constraints.NotNull.message, the default one

I propose to iterate codes so to get the ones built by DefaultMessageCodesResolver cf http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/validation/DefaultMessageCodesResolver.html

I propose a new method because it has an overhead due to the additional iteration and logic which may slow down a bit applications who do not care of customized validation messages.

It works in my environemt.
Please advise where should I add some unit test.

Regards
