### PR TITLE
Add ability to intercept "handleMethodCall"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,7 @@
 						<exclude>**/*.py</exclude>
 						<exclude>**/*.yml</exclude>
 						<exclude>**/.gitignore</exclude>
+						<exclude>**/ExtRequestListener.java</exclude>
 					</excludes>
 					<strictCheck>true</strictCheck>
 				</configuration>
@@ -525,7 +526,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
 

--- a/src/main/java/ch/ralscha/extdirectspring/controller/ExtRequestListener.java
+++ b/src/main/java/ch/ralscha/extdirectspring/controller/ExtRequestListener.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 Daniel Mueller <daniel.mueller@gmx.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.ralscha.extdirectspring.controller;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import ch.ralscha.extdirectspring.bean.ExtDirectRequest;
+import ch.ralscha.extdirectspring.bean.ExtDirectResponse;
+
+public interface ExtRequestListener {
+	void beforeRequest(ExtDirectRequest directRequest, ExtDirectResponse directResponse,
+			HttpServletRequest request, HttpServletResponse response, Locale locale);
+	
+	void afterRequest(ExtDirectRequest directRequest, ExtDirectResponse directResponse,
+			HttpServletRequest request, HttpServletResponse response, Locale locale);
+}

--- a/src/test/java/ch/ralscha/extdirectspring/controller/ApiControllerTest.java
+++ b/src/test/java/ch/ralscha/extdirectspring/controller/ApiControllerTest.java
@@ -954,11 +954,11 @@ public class ApiControllerTest {
 				"withRequiredRequestHeader", Arrays.asList("bd")));
 
 		remotingApi.addAction("remoteProviderSimpleNamed", new Action("nonStrictMethod1",
-				Collections.<String>emptyList(), Boolean.FALSE));
+				Collections.<String> emptyList(), Boolean.FALSE));
 		remotingApi.addAction("remoteProviderSimpleNamed", new Action("nonStrictMethod2",
-				Collections.<String>emptyList(), Boolean.FALSE));
+				Collections.<String> emptyList(), Boolean.FALSE));
 		remotingApi.addAction("remoteProviderSimpleNamed", new Action("nonStrictMethod3",
-				Collections.<String>emptyList(), Boolean.FALSE));
+				Collections.<String> emptyList(), Boolean.FALSE));
 
 		remotingApi.addPollingProvider(new PollingProvider("pollProvider",
 				"handleMessage1", "message1"));


### PR DESCRIPTION
To be able to access the ExtRequest and its Metadata I created the ExtRequestListener that allows to hook before and after the handleMethodCall. If there is a better way to solve this, please le me know :)

Concrete example:
In addition to the default method args, the client sends audit information to the server. I did not want to change the server API, it should be transparent to the developer that this information was send. The ExtRequestLIstener will extract the audit information from the ExtDirectRequest and set it to a ThreadLocal field in our AuditController Bean.