### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,7 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aop</artifactId>
-		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
@@ -113,12 +110,7 @@
 		</dependency>
  		
 		<!-- TEST dependencies -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.4.0</version>
-			<scope>test</scope>
-		</dependency>		
+				
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
@@ -131,12 +123,7 @@
 			<scope>test</scope>
 			<version>5.4.0</version>
 		</dependency>
-		<dependency>
-		    <groupId>org.junit.platform</groupId>
-		    <artifactId>junit-platform-runner</artifactId>
-		    <version>1.4.0</version>
-		    <scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -158,40 +145,15 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.aspectj</groupId>
-			<artifactId>aspectjweaver</artifactId>
-			<version>1.9.4</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.2.3</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.25</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.4</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
-			<scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>joda-time</groupId>
@@ -226,26 +188,11 @@
 			</exclusions>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.13.Final</version>
-			<scope>test</scope>
-		</dependency>
 		
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
-			<version>3.0.0</version>
-			<scope>test</scope>
-		</dependency>
+		
+		
 
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-web</artifactId>
-			<version>5.1.5.RELEASE</version>
-			<scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>org.springframework.security</groupId>
@@ -254,12 +201,7 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-config</artifactId>
-			<version>5.1.5.RELEASE</version>
-			<scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -267,52 +209,19 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-orm</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<version>1.4.199</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-core</artifactId>
-			<version>5.4.1.Final</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.glassfish.jaxb</groupId>
-			<artifactId>jaxb-runtime</artifactId>
-			<version>2.3.0.1</version>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.javassist</groupId>
-			<artifactId>javassist</artifactId>
-			<version>3.25.0-GA</version>
-			<scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
@@ -422,6 +331,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M3</version>
+				<configuration>
+					<parallel>classes</parallel>
+					<useUnlimitedThreads>true</useUnlimitedThreads>
+				</configuration>
+
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
extdirectspring
{groupId='org.springframework', artifactId='spring-aop'}
{groupId='org.junit.platform', artifactId='junit-platform-launcher'}
{groupId='org.junit.platform', artifactId='junit-platform-runner'}
{groupId='org.aspectj', artifactId='aspectjweaver'}
{groupId='ch.qos.logback', artifactId='logback-classic'}
{groupId='org.slf4j', artifactId='jcl-over-slf4j'}
{groupId='commons-fileupload', artifactId='commons-fileupload'}
{groupId='commons-io', artifactId='commons-io'}
{groupId='org.hibernate.validator', artifactId='hibernate-validator'}
{groupId='org.glassfish', artifactId='javax.el'}
{groupId='org.springframework.security', artifactId='spring-security-web'}
{groupId='org.springframework.security', artifactId='spring-security-config'}
{groupId='org.springframework', artifactId='spring-jdbc'}
{groupId='org.springframework', artifactId='spring-orm'}
{groupId='com.h2database', artifactId='h2'}
{groupId='org.hibernate', artifactId='hibernate-core'}
{groupId='javax.xml.bind', artifactId='jaxb-api'}
{groupId='org.glassfish.jaxb', artifactId='jaxb-runtime'}
{groupId='org.javassist', artifactId='javassist'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
